### PR TITLE
Case-related bugfix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "diacritic",
   "main": "diacritics.js",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "authors": [
     "Nijiko Yonskai <nijikokun@gmail.com>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "diacritic",
-  "main": "Diacritics.js",
+  "main": "diacritics.js",
   "version": "0.0.1",
   "authors": [
     "Nijiko Yonskai <nijikokun@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diacritic",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Removes accents / diacritics from strings, sentences, and paragraphs fast and effeciently.",
   "main": "diacritics.js",
   "scripts": {


### PR DESCRIPTION
On a case sensitive OS, including "Diacritics.js" while the file is named "diacritics.js" fails.
Hence the fix + release (note that the version number in bower.json wasn't up to date in 0.0.2).
